### PR TITLE
fix(typings): ensure typings match library code

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -48,8 +48,8 @@ declare module 'testcafe-blink-diff' {
 	 * @description If the given selector does not exists on the DOM, a warning will be raised.
 	 * @description Type `npx testcafe-blink-diff --help` to list all available options.
 	 * @param t The TestController instance
-	 * @param label Readable name for the taken snapshot
-	 * @param options
+	 * @param labelOrOptions Readable name for the taken snapshot, or the {@link TestcafeBlinkDiffOptions} options
+	 * @param options Options to pass to the the takeSnapshot function
 	 */
-    export function takeSnapshot(t: TestController, label: string, options?: TestcafeBlinkDiffOptions): TestController;
+    export function takeSnapshot(t: TestController, labelOrOptions?: string | TestcafeBlinkDiffOptions, options?: TestcafeBlinkDiffOptions): TestController;
 }


### PR DESCRIPTION
I noticed I made some mistakes in the typings. In particular the second parameter can be object options as well as per https://github.com/tacoss/testcafe-blink-diff/blob/f7a2144ae368fbc57417866daf9a80e712d0914c/lib/index.js#L47-L51

And as mentioned in the README no arguments other than the TestController is also valid, so the second parameter should be optional https://github.com/tacoss/testcafe-blink-diff/blob/f7a2144ae368fbc57417866daf9a80e712d0914c/README.md#L24-L25