### PR TITLE
fix: exit with code 1 when catching errors

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -258,6 +258,7 @@ Promise.resolve()
   })
   .catch(e => {
     console.error(`[ERR] ${e.message}`); // eslint-disable-line
+    process.exit(1);
   })
   .then(() => {
     process.exit(exitCode);


### PR DESCRIPTION
I noticed that when a screenshot was missing that the process wasn't exiting with code 1 which caused our CI to report a pass status, when it really isn't a pass status.

The relevant error message is being set on line 138 and that error gets thrown on line 141 in our case as we do not give the `--force` flag. The thrown error then gets caught in Promise.catch(), which previously only logged the error and didn't exit with code 1.

I can't really show the real output logging of our CI as it contains private naming, but here's a simplified sample. Suffice it to say that there's far more screenshots than the one visible here (10+), and in this case more than 1 of those was missing (intentionally now, but it has happened accidentally in the past)
```
yarn run v1.22.5
$ /home/circleci/app/node_modules/.bin/testcafe '/home/circleci/app/src/tests/mobile/**/*.test.ts' --take-snapshot actual
 Running tests in:
 - Chrome 87.0.4280.88 / Linux 0.0

 Test 1
✓ Name (unstable) (screenshots: /home/circleci/app/reports/screenshots)

Test 2
 ✓ Name (screenshots: /home/circleci/app/reports/screenshots/vrt/somename/actual.png)
 ✓ Name 2

 3 passed (1m 31s)

Done in 98.45s.

yarn run v1.22.5
$ /home/circleci/app/node_modules/.bin/testcafe-blink-diff /home/circleci/app/reports/screenshots/vrt /home/circleci/app/reports/blink_diff_report --compare base:actual --threshold 0.05

Collecting screenshots...

[ERR] Missing snapshots for 'fixture testname identifier', given base:actual

Done in 0.17s.
```

All in all I think the best fix is to add the line I added, but if you have a better idea on how to handle this or if I'm wrong as to where the error thrown gets caught then please do share and I'll make the adjustments.

---

As with my previous PR I would very much appreciate a (patch) release to NPM with the fix so we can use it in our testing flow.