### PR TITLE
When using the force flag process should not exit

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -138,11 +138,11 @@ function build() {
       const errorMessage = `Missing snapshots for '${groupedName}'`;
 
       if (!argv.flags.force) {
-        throw new Error(`${errorMessage}, given ${left}:${right}`);
+        console.error(`${errorMessage}, given ${left}:${right}`);
+        process.exit(1);
       }
 
       console.warn(`  ${errorMessage}`); // eslint-disable-line
-      process.exit(1);
     }
 
     const actualImage = path.relative(imagesPath, images[groupedName][right]);


### PR DESCRIPTION
Hi, 

Sorry if I am misunderstanding the purpose of the force flag but as I understand it it should ignore missing snapshots. The current behavior of using or not using the force flag is that you get a warning or an error, but the process is exited both ways (either by process.exit or by throwing a error). If I understand the force flag correctly this is a bug?