### PR TITLE
Fix missing screenshots with --force not breaking build

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -143,6 +143,7 @@ function build() {
       }
 
       console.warn(`  ${errorMessage}`); // eslint-disable-line
+      return;
     }
 
     const actualImage = path.relative(imagesPath, images[groupedName][right]);


### PR DESCRIPTION
My last PR (https://github.com/tacoss/testcafe-blink-diff/pull/32) fixed missing screenshots with --force not exiting. However I failed to notice that it would break later on anyways. 

Currently when there is a missing screenshot and you run it with --force it will break on row 149 or 150 since the path lookup will fail because either paths is undefined. 

This proposed fix simply ignores the comparison. Makes sense because there is nothing to compare. The optimal approach might be to include it in the comparison but to compare it with for example an empty image but that would mean a bigger interference with more code changes. 