### PR TITLE
Replace blink-diff for better blockOut support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Create version
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+          make release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          tags: true
+      - name: Publish version
+        run: npm publish

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.log
 .DS_Store
 dist
+generated
 e2e/screens
 node_modules
 package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,9 @@ deps: package*.json
 
 clean:
 	@rm -rf dist/*
+
+release: deps
+ifneq ($(CI),)
+	@echo '//registry.npmjs.org/:_authToken=$(NODE_AUTH_TOKEN)' > .npmrc
+	@npm version patch
+endif

--- a/e2e/cases/main.test.js
+++ b/e2e/cases/main.test.js
@@ -41,12 +41,12 @@ test('should render "It works!"', async t => {
     Selector('.animated'),
   ];
 
-  await takeSnapshot(t, { label: 'before_assert_blockout', fullPage: true });
+  await takeSnapshot(t, { label: 'before_assert_blockout', blockOut: elements });
 
   await t
     .expect(Selector('h1').exists).ok()
     .expect(Selector('h1').visible).ok()
     .expect(Selector('h1').innerText).contains('It works!');
 
-  await takeSnapshot(t, { label: 'after_assert_blockout', blockOut: elements, fullPage: true });
+  await takeSnapshot(t, { label: 'after_assert_blockout', blockOut: elements });
 });

--- a/e2e/cases/main.test.js
+++ b/e2e/cases/main.test.js
@@ -41,12 +41,12 @@ test('should render "It works!"', async t => {
     Selector('.animated'),
   ];
 
-  await takeSnapshot(t, { label: 'before_assert_blockout', blockOut: elements });
+  await takeSnapshot(t, { label: 'before_assert_blockout', blockOut: elements, fullPage: true });
 
   await t
     .expect(Selector('h1').exists).ok()
     .expect(Selector('h1').visible).ok()
     .expect(Selector('h1').innerText).contains('It works!');
 
-  await takeSnapshot(t, { label: 'after_assert_blockout', blockOut: elements });
+  await takeSnapshot(t, { label: 'after_assert_blockout', blockOut: elements, fullPage: true });
 });

--- a/e2e/public/index.html
+++ b/e2e/public/index.html
@@ -41,4 +41,4 @@
       <div class="g"><span>Sol</span></div>
     </td>
   </tr>
-</table
+</table>

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -10,6 +10,7 @@ Usage:
 
 Options:
   -o, --open       Browse generated report
+  -y, --only       Filter images to process
   -f, --force      Ignore missing screenshots
   -x, --filter     Filter out specific screenshots
   -c, --compare    Custom snapshots, e.g. \`-c base:actual\`
@@ -37,6 +38,7 @@ const argv = wargs(process.argv.slice(2), {
     v: 'version',
     x: 'filter',
     f: 'force',
+    y: 'only',
     o: 'open',
   },
   boolean: 'vfo',
@@ -58,6 +60,7 @@ const destPath = path.resolve(argv._[1] || 'generated');
 const destFile = `${destPath}/index.html`;
 
 const ratio = parseFloat(argv.flags.threshold || '0.01');
+const only = [].concat(argv.flags.only || []);
 
 console.log('Collecting screenshots...');
 
@@ -74,6 +77,8 @@ const sources = require('glob') // eslint-disable-line
 const images = sources
   .filter(x => x.indexOf('thumbnails') === -1)
   .reduce((prev, cur) => {
+    if (only.length && !only.some(x => cur.includes(x))) return prev;
+
     const groupedName = path.basename(cur, '.png');
     const fixedName = `${path.dirname(cur) === '.' ? groupedName : path.dirname(cur)}`
       .replace(/__/g, '§')
@@ -125,6 +130,7 @@ function mkdirp(filepath) {
 }
 
 function build() {
+  let BlinkDiff;
   let failed;
 
   const tasks = [];
@@ -152,9 +158,9 @@ function build() {
     const metaFile = path.join(baseDir, 'blockOut.json');
     const outFile = path.join(baseDir, 'out.png');
 
-    const BlinkDiff = require('blink-diff');
+    BlinkDiff = BlinkDiff || require('blink-diff');
 
-    tasks.push(() => new Promise(resolve => {
+    tasks.push(new Promise(resolve => {
       const blockOut = fs.existsSync(metaFile) ? require(metaFile) : [];
 
       const diff = new BlinkDiff({
@@ -165,10 +171,10 @@ function build() {
         threshold: ratio,
 
         blockOut: blockOut.map(_ => ({
-          x: _.left,
-          y: _.top,
-          width: _.width,
-          height: _.height,
+          x: parseInt(_.left, 10),
+          y: parseInt(_.top, 10),
+          width: parseInt(_.width, 10),
+          height: parseInt(_.height, 10),
         })),
 
         composition: false,
@@ -213,7 +219,7 @@ function build() {
 
   process.stdout.write(`\rProcessing ${tasks.length} file${tasks.length === 1 ? '' : 's'}...\n`); // eslint-disable-line
 
-  return Promise.all(tasks.map(cb => cb())).then(results => ({ failed, results }));
+  return Promise.all(tasks).then(results => ({ failed, results }));
 }
 
 function render(reportInfo) {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs');
 
 const pkgInfo = require('../package.json');
+const ImageDiff = require('./image-diff');
 
 const USAGE_INFO = `
 Usage:
@@ -130,7 +131,6 @@ function mkdirp(filepath) {
 }
 
 function build() {
-  let BlinkDiff;
   let failed;
 
   const tasks = [];
@@ -158,16 +158,13 @@ function build() {
     const metaFile = path.join(baseDir, 'blockOut.json');
     const outFile = path.join(baseDir, 'out.png');
 
-    BlinkDiff = BlinkDiff || require('blink-diff');
-
     tasks.push(new Promise(resolve => {
       const blockOut = fs.existsSync(metaFile) ? require(metaFile) : [];
 
-      const diff = new BlinkDiff({
+      const diff = new ImageDiff({
         imageAPath: images[groupedName][left],
         imageBPath: images[groupedName][right],
 
-        thresholdType: BlinkDiff.THRESHOLD_PERCENT,
         threshold: ratio,
 
         blockOut: blockOut.map(_ => ({
@@ -177,16 +174,15 @@ function build() {
           height: parseInt(_.height, 10),
         })),
 
-        composition: false,
         imageOutputPath: outFile,
       });
 
-      diff.run((error, result) => {
-        process.stdout.write(`  ${groupedName} ${error ? 'FAILED' : 'DONE'}\n`);
-
-        const ok = diff.hasPassed(result.code);
+      diff.run(result => {
         const fixed = ((result.differences / result.dimension) * 100).toFixed(2);
         const errorMessage = `Failed with ${fixed}% of differences`;
+        const ok = diff.hasPassed(fixed);
+
+        process.stdout.write(`  ${groupedName} ${ok ? 'PASS' : 'FAIL'}\n`);
 
         if (!ok) {
           console.warn(`    ${errorMessage}`); // eslint-disable-line

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -180,9 +180,10 @@ function build() {
       diff.run(result => {
         const fixed = ((result.differences / result.dimension) * 100).toFixed(2);
         const errorMessage = `Failed with ${fixed}% of differences`;
+        const fixedName = groupedName.replace(/\//g, ' / ');
         const ok = diff.hasPassed(fixed);
 
-        process.stdout.write(`  ${groupedName} ${ok ? 'PASS' : 'FAIL'}\n`);
+        process.stdout.write(`  ${fixedName} ${ok ? 'PASS' : 'FAIL'}\n`);
 
         if (!ok) {
           console.warn(`    ${errorMessage}`); // eslint-disable-line
@@ -205,7 +206,7 @@ function build() {
           },
           height: result.height,
           width: result.width,
-          label: groupedName.replace(/\//g, ' / '),
+          label: fixedName,
           diff: fixed,
           ok,
         });

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -80,7 +80,7 @@ const images = sources
   .reduce((prev, cur) => {
     if (only.length && !only.some(x => cur.includes(x))) return prev;
 
-    const groupedName = path.basename(cur, '.png');
+    const groupedName = path.basename(cur, '.png').replace(/@[\d.]+$/, '');
     const fixedName = `${path.dirname(cur) === '.' ? groupedName : path.dirname(cur)}`
       .replace(/__/g, '§')
       .replace('-or-', '/')
@@ -131,14 +131,12 @@ function mkdirp(filepath) {
 }
 
 function build() {
-  let failed;
-
   const tasks = [];
-
   const check = (argv.flags.compare || '').split(':');
   const left = check[0] || 'base';
   const right = check[1] || 'actual';
 
+  let failed;
   Object.keys(images).forEach(groupedName => {
     if (!(images[groupedName][left] && images[groupedName][right])) {
       const errorMessage = `Missing snapshots for '${groupedName}'`;
@@ -159,22 +157,17 @@ function build() {
     const outFile = path.join(baseDir, 'out.png');
 
     tasks.push(new Promise(resolve => {
-      const blockOut = fs.existsSync(metaFile) ? require(metaFile) : [];
+      const blocks = fs.existsSync(metaFile) ? require(metaFile) : [];
+      const name = path.basename(images[groupedName][left], '.png');
+      const dpi = name.split('@')[1] || 1;
 
       const diff = new ImageDiff({
+        imageOutputPath: outFile,
         imageAPath: images[groupedName][left],
         imageBPath: images[groupedName][right],
-
+        resolution: dpi,
         threshold: ratio,
-
-        blockOut: blockOut.map(_ => ({
-          x: parseInt(_.left, 10),
-          y: parseInt(_.top, 10),
-          width: parseInt(_.width, 10),
-          height: parseInt(_.height, 10),
-        })),
-
-        imageOutputPath: outFile,
+        blockOut: blocks,
       });
 
       diff.run(() => {
@@ -183,14 +176,14 @@ function build() {
         const fixedName = groupedName.replace(/\//g, ' / ');
         const ok = diff.hasPassed();
 
-        process.stdout.write(`  ${fixedName} ${ok ? 'PASS' : 'FAIL'}\n`);
+        process.stdout.write(`  ${fixedName} (${ok ? '' : 'NOT '}PASS)\n`);
 
         if (!ok) {
           console.warn(`    ${errorMessage}`); // eslint-disable-line
           failed = true;
         }
 
-        sources.push(path.relative(imagesPath, outFile));
+        sources.push(path.relative(imagesPath, diff.getImageOutput()));
 
         const prefix = baseDir === '.' ? '' : path.relative(imagesPath, baseDir);
 
@@ -202,12 +195,13 @@ function build() {
           images: {
             actual: actualImage,
             base: baseImage,
-            out: path.relative(imagesPath, outFile),
+            out: path.relative(imagesPath, diff.getImageOutput()),
           },
           height: diff.height,
           width: diff.width,
           label: fixedName,
           diff: fixed,
+          dpi,
           ok,
         });
       });

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -177,11 +177,11 @@ function build() {
         imageOutputPath: outFile,
       });
 
-      diff.run(result => {
-        const fixed = ((result.differences / result.dimension) * 100).toFixed(2);
+      diff.run(() => {
+        const fixed = diff.getDifference();
         const errorMessage = `Failed with ${fixed}% of differences`;
         const fixedName = groupedName.replace(/\//g, ' / ');
-        const ok = diff.hasPassed(fixed);
+        const ok = diff.hasPassed();
 
         process.stdout.write(`  ${fixedName} ${ok ? 'PASS' : 'FAIL'}\n`);
 
@@ -204,8 +204,8 @@ function build() {
             base: baseImage,
             out: path.relative(imagesPath, outFile),
           },
-          height: result.height,
-          width: result.width,
+          height: diff.height,
+          width: diff.width,
           label: fixedName,
           diff: fixed,
           ok,

--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -1,6 +1,5 @@
 const { readPngFileSync, writePngFileSync, colorRGBA, rect } = require('node-libpng');
 const { diffImages } = require('native-image-diff');
-const path = require('path');
 
 class ImageDiff {
   constructor(opts) {

--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -4,6 +4,10 @@ const { diffImages } = require('native-image-diff');
 class ImageDiff {
   constructor(opts) {
     this.options = { ...opts };
+    this.width = 0;
+    this.height = 0;
+    this.dimension = 0;
+    this.differences = 0;
   }
 
   run(callback) {
@@ -24,15 +28,22 @@ class ImageDiff {
 
     writePngFileSync(this.options.imageOutputPath, image.data, { width: image.width, height: image.height });
 
-    callback({
+    callback(Object.assign(this, {
       width: image.width,
       height: image.height,
       dimension: totalDelta,
       differences: pixels,
-    });
+    }));
   }
 
-  hasPassed(percentage) {
+  getDifference() {
+    return this.differences && this.dimension
+      ? ((this.differences / this.dimension) * 100).toFixed(2)
+      : 0;
+  }
+
+  hasPassed() {
+    const percentage = this.getDifference();
     return percentage <= this.options.threshold;
   }
 }

--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -1,5 +1,6 @@
 const { readPngFileSync, writePngFileSync, colorRGBA, rect } = require('node-libpng');
 const { diffImages } = require('native-image-diff');
+const path = require('path');
 
 class ImageDiff {
   constructor(opts) {
@@ -7,6 +8,7 @@ class ImageDiff {
     this.width = 0;
     this.height = 0;
     this.dimension = 0;
+    this.resolution = 0;
     this.differences = 0;
   }
 
@@ -17,16 +19,22 @@ class ImageDiff {
     if (this.options.blockOut) {
       const aColor = colorRGBA(255, 0, 0, 1);
       const bColor = colorRGBA(255, 0, 0, 1);
+      const dpi = this.options.resolution || 1;
 
       [].concat(this.options.blockOut).forEach(area => {
-        aImage.fill(aColor, rect(area.x - 1, area.y - 1, area.width + 2, area.height + 2));
-        bImage.fill(bColor, rect(area.x - 1, area.y - 1, area.width + 2, area.height + 2));
+        const x = (area.left * dpi) - 1;
+        const y = (area.top * dpi) - 1;
+        const w = (area.width * dpi) + 2;
+        const h = (area.height * dpi) + 2;
+
+        aImage.fill(aColor, rect(x, y, w, h));
+        bImage.fill(bColor, rect(x, y, w, h));
       });
     }
 
     const { image, pixels, totalDelta } = diffImages(aImage, bImage);
 
-    writePngFileSync(this.options.imageOutputPath, image.data, { width: image.width, height: image.height });
+    writePngFileSync(this.getImageOutput(), image.data, { width: image.width, height: image.height });
 
     callback(Object.assign(this, {
       width: image.width,
@@ -34,6 +42,10 @@ class ImageDiff {
       dimension: totalDelta,
       differences: pixels,
     }));
+  }
+
+  getImageOutput() {
+    return this.options.imageOutputPath;
   }
 
   getDifference() {

--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -1,4 +1,4 @@
-const { readPngFileSync, writePngFileSync } = require('node-libpng');
+const { readPngFileSync, writePngFileSync, colorRGBA, rect } = require('node-libpng');
 const { diffImages } = require('native-image-diff');
 
 class ImageDiff {
@@ -7,7 +7,20 @@ class ImageDiff {
   }
 
   run(callback) {
-    const { image, pixels, totalDelta } = diffImages(readPngFileSync(this.options.imageAPath), readPngFileSync(this.options.imageBPath));
+    const aImage = readPngFileSync(this.options.imageAPath);
+    const bImage = readPngFileSync(this.options.imageBPath);
+
+    if (this.options.blockOut) {
+      const aColor = colorRGBA(255, 0, 0, 1);
+      const bColor = colorRGBA(255, 0, 0, 1);
+
+      [].concat(this.options.blockOut).forEach(area => {
+        aImage.fill(aColor, rect(area.x, area.y, area.width, area.height));
+        bImage.fill(bColor, rect(area.x, area.y, area.width, area.height));
+      });
+    }
+
+    const { image, pixels, totalDelta } = diffImages(aImage, bImage);
 
     writePngFileSync(this.options.imageOutputPath, image.data, { width: image.width, height: image.height });
 

--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -1,0 +1,27 @@
+const { readPngFileSync, writePngFileSync } = require('node-libpng');
+const { diffImages } = require('native-image-diff');
+
+class ImageDiff {
+  constructor(opts) {
+    this.options = { ...opts };
+  }
+
+  run(callback) {
+    const { image, pixels, totalDelta } = diffImages(readPngFileSync(this.options.imageAPath), readPngFileSync(this.options.imageBPath));
+
+    writePngFileSync(this.options.imageOutputPath, image.data, { width: image.width, height: image.height });
+
+    callback({
+      width: image.width,
+      height: image.height,
+      dimension: totalDelta,
+      differences: pixels,
+    });
+  }
+
+  hasPassed(percentage) {
+    return percentage <= this.options.threshold;
+  }
+}
+
+module.exports = ImageDiff;

--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -19,8 +19,8 @@ class ImageDiff {
       const bColor = colorRGBA(255, 0, 0, 1);
 
       [].concat(this.options.blockOut).forEach(area => {
-        aImage.fill(aColor, rect(area.x, area.y, area.width, area.height));
-        bImage.fill(bColor, rect(area.x, area.y, area.width, area.height));
+        aImage.fill(aColor, rect(area.x - 1, area.y - 1, area.width + 2, area.height + 2));
+        bImage.fill(bColor, rect(area.x - 1, area.y - 1, area.width + 2, area.height + 2));
       });
     }
 

--- a/lib/index.html
+++ b/lib/index.html
@@ -5,11 +5,13 @@
     <title>testcafe-blink-diff</title>
     <style>
       * { margin: 0; padding: 0; }
+      *, *::before, *::after { box-sizing: border-box; }
       body { font-family: Helvetica; }
       ul { list-style-type: none; max-width: 760px; margin: auto; }
       li { margin-top: 20px; }
       button { padding: 5px 10px; background-color: transparent; }
       button ~ button { margin-left: 5px; }
+      img.noop { outline: 1px dashed rgba(0, 0, 0, .5); }
       .noop { -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; }
       .flex { display: flex; text-align: center; align-items: center; justify-content: center; }
       .info { min-width: 33.3%; }
@@ -17,17 +19,25 @@
       .passed::before { content: '✓ '; font-size: 30px; }
       .failed { color: red; }
       .failed::before { content: '✗ '; font-size: 30px; }
-      .modal { position: fixed; left: 0; top: 0; width: 100%; height: 100%; background-color: rgba(0, 0, 0, .5); overflow: auto; }
-      .container { position: absolute; overflow: auto; margin: auto; top: 0; left: 0; right: 0; bottom: 0; }
-      .layer { position: absolute; width: 100%; height: 100%; overflow: hidden; }
+      .modal { opacity: 0; transition: opacity .2s; position: absolute; left: 0; top: 0; margin: auto; }
+      .modal::before { position: fixed; content: ''; top: 0; left: 0; right: 0; bottom: 0; background-image: url(data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAwQDAwQGBAMEBgcFBAQFBwgGBgcGBggKCAkJCQkICgoMDAwMDAoMDA0NDAwRERERERQUFBQUFBQUFBT/2wBDAQQFBQgHCA8KCg8UDg4OFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAAoACgDAREAAhEBAxEB/8QAFwABAQEBAAAAAAAAAAAAAAAAAAUGCP/EACIQAQAABQMFAQAAAAAAAAAAAAAFFUNjgqLB4RESEzVRkf/EABQBAQAAAAAAAAAAAAAAAAAAAAD/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwDv4AE6K0stgTgAaIAE6K0stgTgAUZra1cATW1q4A9na8WXXu/PgEqu6eQJVd08gnAAowqrjuCiADOgAowqrjuCiAD/2Q==); }
+      .modal.ready { opacity: 1 }
+      .layer { position: absolute; width: 100%; height: 100%; top: 0; }
       .layer > img { display: block; vertical-align: middle; }
-      .overlay { border-right: 1px solid rgba(255, 0, 255, .5); overflow: hidden; }
-      .slider { position: absolute; z-index: 1; cursor: ew-resize; width: 32px; height: 32px; background-color: #ff00ff; border: 1px solid rgba(255, 0, 255, .5); border-radius: 50%; transition: background-color .3s }
-      .close { position: fixed; right: 10px; top: 10px; background-color: rgba(0, 0, 0, .5); width: 30px; height: 30px; border-radius: 50%; color: white; border: 0; }
-      .keys { position: fixed; left: 5px; bottom: 5px; background-color: rgba(255, 255, 255, .8); }
+      .container { z-index: 1; position: relative; box-shadow: 0 1px 3px rgba(0, 0, 0, .5); overflow: hidden; height: inherit; }
+      .overlay { overflow: hidden; }
+      .overlay::after { opacity: 0; transition: opacity .2s; z-index: 1; content: ''; position: absolute; width: 1px; background-color: #00FFFF; height: 100%; right: 0; top: 0; }
+      .slider { pointer-events: none; opacity: 0; transition: opacity .2s; position: relative; z-index: 1; cursor: ew-resize; width: 32px; height: 32px; background-color: #00FFFF; border-radius: 50%; top: 50vh; line-height: 32px; text-align: center; color: #fff; text-shadow: 1px 1px 0 rgba(0, 0, 0, .3); font-size: 12px; }
+      .right { transition: top .2s; z-index: 1; position: fixed; right: 10px; top: -50px; display: flex; gap: 10px; align-items: center; }
+      .close { background-color: rgba(0, 0, 0, .5); width: 30px; height: 30px; border-radius: 50%; color: white; border: 0; }
+      .right, .keys { background-color: rgba(255, 255, 255, .87); padding: 5px 10px; border-radius: 3px; }
+      .keys { position: fixed; left: 5px; bottom: 5px; }
       .keys kbd { border-radius: 3px; background-color: rgba(255, 255, 255, .8); box-shadow: 0 1px 3px rgba(0, 0, 0, .5); padding: 0 .3em; }
       .keys li { margin: 0; }
       .keys li + li { margin-top: 5px; }
+      .moving .modal .right { top: 10px; }
+      .moving .modal .slider { opacity: 1; pointer-events: all; }
+      .moving .modal .overlay::after { opacity: 1; }
     </style>
   </head>
   <body>
@@ -36,9 +46,9 @@
 </script>
     <ul class="keys">
       <li><kbd>ESC</kbd> &mdash; <small>To close open Modal</small></li>
-      <li><kbd>SPACE</kbd> &mdash; <small>Switch between diff/compare views in Modal mode</small></li>
-      <li><kbd>LEFT</kbd> <small>or</small> <kbd>RIGHT</kbd> &mdash; <small>Go to previous and next image in Modal mode</small></li>
-      <li><kbd>SHIFT</kbd> <small>+</small> <kbd>LEFT</kbd> <small>or</small> <kbd>RIGHT</kbd> &mdash; <small>Move handle horizontally from diff view on Modal mode</small></li>
+      <li><kbd>SPACE</kbd> &mdash; <small>Toggle difference-overlay image</small></li>
+      <li><kbd>TAB</kbd> <small>or</small> <kbd>SHIFT</kbd> <small>+</small> <kbd>TAB</kbd> &mdash; <small>Go to next and previous image</small></li>
+      <li><kbd>LEFT</kbd> <small>or</small> <kbd>RIGHT</kbd> &mdash; <small>Move diff-handle by 100px (use </small><kbd>SHIFT</kbd> <small>to move by 10px)</small></li>
     </ul>
   </body>
 </html>

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,14 +76,20 @@ function _takeSnapshot(t, opts, extra) {
 
   const getWindowDPI = ClientFunction(() => window.devicePixelRatio);
 
+  let dpi;
+  function fixedName() {
+    return dpi > 1 ? imagePath.replace('.png', `@${dpi}.png`) : imagePath;
+  }
+
   return Promise.resolve()
     .then(() => t.wait(options.timeout === false ? 0 : (options.timeout || 500)))
+    .then(() => getWindowDPI().then(value => { dpi = value || 1; }))
     .then(() => {
       if (!selectors) {
 
         return Promise.resolve()
           // testcafe's api for takeScreenshot has changed: https://devexpress.github.io/testcafe/documentation/test-api/actions/take-screenshot.html
-          .then(() => !found && t.takeScreenshot({ path: imagePath, fullPage: options.fullPage }))
+          .then(() => !found && t.takeScreenshot({ path: fixedName(), fullPage: options.fullPage }))
           .then(() => { found = !!exists; });
       }
     })
@@ -100,7 +106,7 @@ function _takeSnapshot(t, opts, extra) {
           return Promise.resolve()
             .then(() => sel.exists)
             .then(ok => { return exists = ok; })
-            .then(ok => (ok && !found ? t.takeElementScreenshot(sel, imagePath) : notFound(sel)))
+            .then(ok => (ok && !found ? t.takeElementScreenshot(sel, fixedName()) : notFound(sel)))
             .then(() => { found = !!exists; });
         });
       }, Promise.resolve());
@@ -111,7 +117,6 @@ function _takeSnapshot(t, opts, extra) {
         const blocks = Array.isArray(options.blockOut) ? options.blockOut : [options.blockOut];
         const results = [];
 
-        let dpi;
         return Promise.all(blocks.map(x => {
           if (typeof x !== 'function') {
             debug(`Expecting a Selector() instance, given '${x}'`, options);
@@ -138,7 +143,7 @@ function _takeSnapshot(t, opts, extra) {
             .then(_results => {
               results.push(..._results);
             });
-        })).then(() => getWindowDPI().then(value => { dpi = value || 1; })).then(() => {
+        })).then(() => {
           let screenshotsDir = t.testRun.opts.screenshotPath || (t.testRun.opts.screenshots || {}).path;
           if (!screenshotsDir) {
             debug(`Unable to read screenshots.path, using current dir`, options);
@@ -148,14 +153,7 @@ function _takeSnapshot(t, opts, extra) {
           const baseDir = path.join(screenshotsDir, path.dirname(imagePath));
           const metaFile = path.join(baseDir, 'blockOut.json');
 
-          fs.writeFileSync(metaFile, JSON.stringify(results.filter(Boolean).map(x => ({
-            top: x.top * dpi,
-            left: x.left * dpi,
-            right: x.right * dpi,
-            bottom: x.bottom * dpi,
-            width: x.width * dpi,
-            height: x.height * dpi,
-          }))));
+          fs.writeFileSync(metaFile, JSON.stringify(results.filter(Boolean)));
         });
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 
 require('global-or-local').devDependencies(['testcafe']);
 
-const { Selector } = require('testcafe');
+const { Selector, ClientFunction } = require('testcafe');
 const path = require('path');
 const fs = require('fs');
 
@@ -16,7 +16,6 @@ const type = (snapshotName && snapshotName.match(/^[a-z\d_]/) ? snapshotName : n
 
 function getCurrentStack() {
   let found;
-
   return (new Error()).stack.split('\n').filter(x => {
     if (x.indexOf('anonymous') !== -1) return false;
     if (found || x.indexOf(' at ') === -1) return true;
@@ -67,7 +66,6 @@ function _takeSnapshot(t, opts, extra) {
   let exists;
   let found;
   let skip;
-
   function notFound(x) {
     skip = true;
 
@@ -75,6 +73,8 @@ function _takeSnapshot(t, opts, extra) {
 
     debug(`Selector('${x[key].fn}') was not found on the DOM`, options);
   }
+
+  const getWindowDPI = ClientFunction(() => window.devicePixelRatio);
 
   return Promise.resolve()
     .then(() => t.wait(options.timeout === false ? 0 : (options.timeout || 500)))
@@ -111,6 +111,7 @@ function _takeSnapshot(t, opts, extra) {
         const blocks = Array.isArray(options.blockOut) ? options.blockOut : [options.blockOut];
         const results = [];
 
+        let dpi;
         return Promise.all(blocks.map(x => {
           if (typeof x !== 'function') {
             debug(`Expecting a Selector() instance, given '${x}'`, options);
@@ -118,7 +119,6 @@ function _takeSnapshot(t, opts, extra) {
           }
 
           let result;
-
           return Promise.resolve()
             .then(() => x.with({ boundTestRun: t }))
             .then(_result => Promise.resolve()
@@ -138,9 +138,8 @@ function _takeSnapshot(t, opts, extra) {
             .then(_results => {
               results.push(..._results);
             });
-        })).then(() => {
+        })).then(() => getWindowDPI().then(value => { dpi = value || 1; })).then(() => {
           let screenshotsDir = t.testRun.opts.screenshotPath || (t.testRun.opts.screenshots || {}).path;
-
           if (!screenshotsDir) {
             debug(`Unable to read screenshots.path, using current dir`, options);
             screenshotsDir = path.dirname(t.testRun.test.testFile.filename);
@@ -149,7 +148,14 @@ function _takeSnapshot(t, opts, extra) {
           const baseDir = path.join(screenshotsDir, path.dirname(imagePath));
           const metaFile = path.join(baseDir, 'blockOut.json');
 
-          fs.writeFileSync(metaFile, JSON.stringify(results.filter(Boolean)));
+          fs.writeFileSync(metaFile, JSON.stringify(results.filter(Boolean).map(x => ({
+            top: x.top * dpi,
+            left: x.left * dpi,
+            right: x.right * dpi,
+            bottom: x.bottom * dpi,
+            width: x.width * dpi,
+            height: x.height * dpi,
+          }))));
         });
       }
     });

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-import": "^2.22.1",
     "is-svg": ">=4.2.2",
     "sirv-cli": "^1.0.8",
-    "somedom": "^0.4.18",
+    "somedom": "^0.4.19",
     "testcafe": "^1.20.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
   "author": "Alvaro Cabrera <pateketrueke@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "blink-diff": "^1.0.13",
     "glob": "^7.1.6",
     "global-or-local": "^0.1.7",
+    "native-image-diff": "^0.1.14",
+    "node-libpng": "^0.2.20",
     "open": "^7.3.0",
     "wargs": "^0.9.6"
   },

--- a/package.json
+++ b/package.json
@@ -19,33 +19,26 @@
     "serve": "sirv e2e/public --port 3000",
     "prepublish": "npm run dist",
     "test": "npm run test:e2e -- -a 'npm run serve' e2e/cases",
-    "test:e2e": "BASE_URL=http://localhost:3000 testcafe ${BROWSER:-chrome:headless} --screenshots-full-page --take-snapshot -s e2e/screens"
+    "test:e2e": "BASE_URL=http://localhost:3000 testcafe ${BROWSER:-chrome:headless} --screenshots-full-page --take-snapshot ${SNAPSHOT} -s e2e/screens"
   },
   "author": "Alvaro Cabrera <pateketrueke@gmail.com>",
   "license": "MIT",
   "dependencies": {
     "blink-diff": "^1.0.13",
     "glob": "^7.1.6",
-    "global-or-local": "^0.1.6",
+    "global-or-local": "^0.1.7",
     "open": "^7.3.0",
-    "wargs": "^0.9.2"
+    "wargs": "^0.9.6"
   },
   "devDependencies": {
     "bili": "^5.0.5",
-    "browserslist": ">=4.16.5",
     "eslint": "^7.11.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.22.1",
-    "glob-parent": ">=5.1.2",
     "is-svg": ">=4.2.2",
-    "minimist": ">=1.2.5",
-    "postcss": ">=7.0.36",
-    "serialize-javascript": ">=5.0.1",
     "sirv-cli": "^1.0.8",
-    "somedom": "^0.1.9",
-    "testcafe": "^1.15.3",
-    "underscore": ">=1.12.1",
-    "ws": ">=5.2.3"
+    "somedom": "^0.4.18",
+    "testcafe": "^1.20.1"
   },
   "peerDependencies": {
     "testcafe": "^1.9.4"

--- a/src/index.js
+++ b/src/index.js
@@ -16,20 +16,17 @@ function ImageItem(props, key) {
       ['img.noop', { src: props.thumbnails.actual }],
       ['.info', { class: props.ok ? 'passed' : 'failed' }, [
         ['h3', null, props.ok ? 'It passed.' : 'It did not passed'],
-        ['h2', null, `Diff: ${props.diff}%`],
-        ['button.noop', { onclick: () => openModal(key, true, images) }, 'Open diff'],
-        ['button.noop', { onclick: () => openModal(key, false, images) }, 'Compare'],
+        ['h2', null, props.diff > 0 ? `Diff: ${props.diff}%` : 'No differences'],
+        ['button.noop', { onclick: () => openModal(key, images) }, 'Compare'],
       ]],
     ]],
   ]];
 }
 
 function ImageList() {
-  if (!images.length) {
-    return ['ul', null, [['li', null, 'No differences to report']]];
-  }
-
-  return ['ul', null, images.map((x, key) => ImageItem(x, key))];
+  return !images.length
+    ? ['ul', null, [['li', null, 'No differences to report']]]
+    : ['ul', null, images.map((x, key) => ImageItem(x, key))];
 }
 
 mount([ImageList], tag);

--- a/src/index.js
+++ b/src/index.js
@@ -9,14 +9,14 @@ const images = JSON.parse(appScript.innerHTML);
 appScript.parentNode.removeChild(appScript);
 
 function ImageItem(props, key) {
-  return ['li', [
-    ['strong', props.label],
-    ['.flex', [
+  return ['li', null, [
+    ['strong', null, props.label],
+    ['.flex', null, [
       ['img.noop', { src: props.thumbnails.base }],
       ['img.noop', { src: props.thumbnails.actual }],
       ['.info', { class: props.ok ? 'passed' : 'failed' }, [
-        ['h3', props.ok ? 'It passed.' : 'It did not passed'],
-        ['h2', `Diff: ${props.diff}%`],
+        ['h3', null, props.ok ? 'It passed.' : 'It did not passed'],
+        ['h2', null, `Diff: ${props.diff}%`],
         ['button.noop', { onclick: () => openModal(key, true, images) }, 'Open diff'],
         ['button.noop', { onclick: () => openModal(key, false, images) }, 'Compare'],
       ]],
@@ -26,10 +26,10 @@ function ImageItem(props, key) {
 
 function ImageList() {
   if (!images.length) {
-    return ['ul', [['li', 'No differences to report']]];
+    return ['ul', null, [['li', null, 'No differences to report']]];
   }
 
-  return ['ul', images.map((x, key) => ImageItem(x, key))];
+  return ['ul', null, images.map((x, key) => ImageItem(x, key))];
 }
 
 mount([ImageList], tag);

--- a/src/modal.js
+++ b/src/modal.js
@@ -1,5 +1,5 @@
 import {
-  bind, view, mount, unmount, render, listeners, attributes, classes,
+  bind, view, unmount, render, listeners, attributes, classes,
 } from 'somedom';
 
 export const tag = bind(render, listeners(), attributes({
@@ -97,7 +97,7 @@ export function mountOverlay(overlay, slider) {
       return parseInt(overlay.current.style.width, 10);
     },
     update() {
-      clickUp(3000);
+      clickUp();
     },
     teardown() {
       slider.current.removeEventListener('mousedown', slideReady);

--- a/src/modal.js
+++ b/src/modal.js
@@ -167,10 +167,10 @@ export function openModal(offsetKey, asDiff, images) {
         ? [
           ['img', { src: images[key].images.out, ...scaleImage(images[key]) }],
         ] : [
-          ['.layer', [
+          ['.layer', null, [
             ['img.a', { src: images[key].images.actual, ...scaleImage(images[key]) }],
           ]],
-          ['.layer.overlay', [
+          ['.layer.overlay', null, [
             ['img.b', { src: images[key].images.base, ...scaleImage(images[key]) }],
           ]],
         ])

--- a/src/modal.js
+++ b/src/modal.js
@@ -6,54 +6,65 @@ export const tag = bind(render, listeners(), attributes({
   class: classes,
 }));
 
-export function mountOverlay(overlay) {
-  let w;
-  let h;
+export function mountOverlay(overlay, slider) {
+  let container;
+  let maximum;
   let clicked;
-
-  const slider = mount(overlay.parentNode, ['div', { class: 'slider' }], tag);
+  function set() {
+    slider.current.style.transform = `translateY(${scrollY}px)`;
+  }
 
   function sync() {
-    w = overlay.parentNode.offsetWidth;
-    h = overlay.parentNode.offsetHeight;
-
-    overlay.style.width = `${w / 2}px`;
-
-    slider.style.left = `${(w / 2) - (slider.offsetWidth / 2)}px`;
-    slider.style.top = `${(h / 2) - (slider.offsetHeight / 2)}px`;
+    container = overlay.current.parentNode.offsetWidth;
+    maximum = Math.min(document.body.clientWidth, container);
+    slider.current.style.left = `${(maximum / 2) - (slider.current.offsetWidth / 2)}px`;
+    overlay.current.style.width = `${maximum / 2}px`;
   }
 
   function slide(x) {
-    overlay.style.width = `${x}px`;
-    slider.style.left = `${overlay.offsetWidth - (slider.offsetWidth / 2)}px`;
+    overlay.current.style.width = `${x}px`;
+    slider.current.style.left = `${overlay.current.offsetWidth - (slider.current.offsetWidth / 2)}px`;
   }
 
   function getCursorPos(e) {
-    const a = overlay.getBoundingClientRect();
+    const a = overlay.current.getBoundingClientRect();
 
     let x = (e || window.event).pageX - a.left;
-
     x -= window.pageXOffset;
 
     return x;
   }
 
-  function slideMove(e) {
-    let pos;
+  let moving;
+  let t;
+  function clickUp() {
+    if (!moving) {
+      moving = true;
+      document.body.classList.add('moving');
+    }
 
+    clearTimeout(t);
+    t = setTimeout(() => {
+      if (moving) {
+        moving = false;
+        document.body.classList.remove('moving');
+      }
+    }, 1260);
+  }
+
+  function slideMove(e) {
+    clearTimeout(t);
+
+    let pos;
     if (!clicked) {
+      clickUp();
       return false;
     }
 
     pos = getCursorPos(e);
 
-    if (pos < 0) {
-      pos = 0;
-    }
-
-    if (pos > w) {
-      pos = w;
-    }
+    if (pos < 0) pos = 0;
+    if (pos > container) pos = container;
 
     slide(pos);
   }
@@ -61,67 +72,84 @@ export function mountOverlay(overlay) {
   function slideReady(e) {
     e.preventDefault();
     clicked = 1;
-
-    window.addEventListener('mousemove', slideMove);
-    window.addEventListener('touchmove', slideMove);
   }
 
   function slideFinish() {
+    clickUp();
     clicked = 0;
   }
 
   sync();
-
-  slider.addEventListener('mousedown', slideReady);
-  slider.addEventListener('touchstart', slideReady);
-  window.addEventListener('mouseup', slideFinish);
-  window.addEventListener('touchstop', slideFinish);
+  slider.current.addEventListener('mousedown', slideReady);
+  slider.current.addEventListener('touchstart', slideReady);
+  addEventListener('mouseup', slideFinish);
+  addEventListener('touchstop', slideFinish);
+  addEventListener('mousemove', slideMove);
+  addEventListener('touchmove', slideMove);
+  addEventListener('resize', sync);
+  addEventListener('scroll', set);
 
   return {
     set width(value) {
       slide(value);
     },
     get width() {
-      return parseInt(overlay.style.width, 10);
+      return parseInt(overlay.current.style.width, 10);
     },
     update() {
-      sync();
+      clickUp(3000);
     },
     teardown() {
-      slider.removeEventListener('mousedown', slideReady);
-      slider.removeEventListener('touchstart', slideReady);
-      window.removeEventListener('mouseup', slideFinish);
-      window.removeEventListener('touchstop', slideFinish);
-      window.removeEventListener('mousemove', slideMove);
-      window.removeEventListener('touchmove', slideMove);
-      unmount(slider);
+      slider.current.removeEventListener('mousedown', slideReady);
+      slider.current.removeEventListener('touchstart', slideReady);
+      removeEventListener('mouseup', slideFinish);
+      removeEventListener('touchstop', slideFinish);
+      removeEventListener('mousemove', slideMove);
+      removeEventListener('touchmove', slideMove);
+      removeEventListener('resize', sync);
+      removeEventListener('scroll', set);
+      unmount(slider.current);
     },
   };
 }
 
-export function openModal(offsetKey, asDiff, images) {
+export function openModal(offsetKey, images) {
   let overlay;
   let modal;
-
-  function onClose(callback) {
-    window.removeEventListener('keyup', callback);
+  let top;
+  function onClose(onKeys) {
+    window.removeEventListener('keydown', onKeys);
 
     document.body.style.overflow = '';
 
     if (overlay) {
       overlay.teardown();
+      overlay = null;
     }
 
     modal.unmount();
+    scrollTo({ behavior: 'instant', left: 0, top });
   }
 
   function testKeys(e) {
-    if (e.keyCode === 37) modal.prev(e);
-    if (e.keyCode === 39) modal.next(e);
+    if (e.keyCode === 9) {
+      e.preventDefault();
+      if (e.shiftKey) modal.prev(e);
+      else modal.next(e);
+      overlay.update();
+    }
+
+    if (e.keyCode === 37 || e.keyCode === 39) {
+      e.preventDefault();
+      if (e.keyCode === 37) modal.left(e);
+      if (e.keyCode === 39) modal.right(e);
+      overlay.update();
+    }
 
     if (e.keyCode === 32) {
       e.preventDefault();
       modal.change();
+      overlay.update();
     }
 
     if (e.keyCode === 27) {
@@ -135,94 +163,68 @@ export function openModal(offsetKey, asDiff, images) {
     }
   }
 
-  function addOverlay() {
-    return mountOverlay(document.querySelector('.overlay'));
-  }
-
-  function syncOverlay() {
-    if (overlay) {
-      overlay.update();
-    }
-  }
-
   function scaleImage(img) {
-    if (img.width > screen.width || img.height > screen.height) {
-      return { width: img.width / 2, height: img.height / 2 };
-    }
+    return { width: img.width / img.dpi, height: img.height / img.dpi };
   }
 
   function scaleOverlay(img) {
-    if (img.width > screen.width || img.height > screen.height) {
-      return 'width:100%;height:100%';
-    }
-
-    return `width:${img.width}px;height:${img.height}px`;
+    return [
+      `width:${img.width / img.dpi}px;height:${img.height / img.dpi}px`,
+      (img.width / img.dpi) < document.body.clientWidth ? `;right:0` : '',
+      (img.height / img.dpi) < document.body.clientHeight ? `;bottom:0` : '',
+    ].join('');
   }
 
-  window.addEventListener('keyup', testKeys);
+  window.addEventListener('keydown', testKeys);
 
-  const app = view(({ key, diff }) => ['.noop.modal', { onclick: closeModal }, [
-    ['.container', { style: scaleOverlay(images[key]), onupdate: syncOverlay },
-      (diff
-        ? [
-          ['img', { src: images[key].images.out, ...scaleImage(images[key]) }],
-        ] : [
-          ['.layer', null, [
-            ['img.a', { src: images[key].images.actual, ...scaleImage(images[key]) }],
-          ]],
-          ['.layer.overlay', null, [
-            ['img.b', { src: images[key].images.base, ...scaleImage(images[key]) }],
-          ]],
-        ])
-        .concat([
+  const overlayRef = {};
+  const sliderRef = {};
+
+  const app = view(({ key, diff }) => {
+    const current = images[key];
+    const props = scaleImage(current);
+
+    return ['.noop.modal', {
+      onclick: closeModal,
+      style: scaleOverlay(current),
+      oncreate(el) {
+        requestAnimationFrame(() => el.classList.add('ready'));
+      },
+    },
+      ['.container', null, [
+        ['.layer', null, [
+          ['img.a', { src: current.images.actual, ...props }],
+        ]],
+        ['.layer.overlay', { ref: overlayRef }, [
+          ['img.b', { src: current.images.base, ...props }],
+        ]],
+        ['.slider', { ref: sliderRef }],
+        ['span.right', null, [
+          ['small', null, ['b', null, `${current.label} ${current.width / current.dpi}x${current.height / current.dpi} (${key + 1}/${images.length})`]],
           ['button.close', { onclick: () => closeModal() }, '×'],
-        ]),
-    ],
-  ]], {
-    diff: asDiff,
+        ]],
+        diff ? ['.layer.difference', null, [
+          ['img.c', { src: current.images.out, ...props }],
+        ]] : null,
+      ]],
+    ];
+  }, {
+    diff: true,
     key: offsetKey,
   }, {
-    next: e => ({ key, diff }) => {
-      if (!diff && e.shiftKey) {
-        overlay.width = Math.min(images[key].width, overlay.width + (images[key].width * 0.25));
-        return;
-      }
-
-      return {
-        key: Math.min(key + 1, images.length - 1),
-      };
+    next: e => ({ key }) => ({ key: key < images.length - 1 ? Math.min(key + 1, images.length - 1) : 0 }),
+    prev: e => ({ key }) => ({ key: key > 0 ? Math.max(key - 1, 0) : images.length - 1 }),
+    left: e => () => {
+      overlay.width = Math.max(0, overlay.width - (!e.shiftKey ? 100 : 10));
     },
-    prev: e => ({ key, diff }) => {
-      if (!diff && e.shiftKey) {
-        overlay.width = Math.max(0, overlay.width - (images[key].width * 0.25));
-        return;
-      }
-
-      return {
-        key: Math.max(key - 1, 0),
-      };
+    right: e => ({ key }) => {
+      overlay.width = Math.min(images[key].width, overlay.width + (!e.shiftKey ? 100 : 10));
     },
-    change: () => ({ diff }) => {
-      if (overlay) {
-        overlay.teardown();
-        overlay = null;
-      } else if (diff) {
-        setTimeout(() => {
-          overlay = addOverlay();
-        });
-      }
-
-      return {
-        diff: !diff,
-      };
-    },
+    change: () => ({ diff }) => ({ diff: !diff }),
   });
 
+  top = scrollY;
   modal = app(document.body, tag);
-
-  document.body.style.overflow = 'hidden';
-
-  if (!asDiff) {
-    overlay = addOverlay();
-  }
+  overlay = mountOverlay(overlayRef, sliderRef);
+  scrollTo({ behavior: 'instant', left: 0, top: 0 });
 }


### PR DESCRIPTION
Since `blink-diff` is an archived repository, I had to look for alternatives.

And we're lucky, with `native-image-diff` and `node-libpng` we can replace it completely.

By the way I reworked the UI to keeping it up with the good news!

I hope is not too late for closing #13 and #38 #39