### PR TITLE
add SNAPSHOT_NAME env var

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 
 const isFullPage = process.env.FULL_PAGE || (process.argv.slice(2).indexOf('--full-page') !== -1);
 const isTakeSnapshot = process.env.TAKE_SNAPSHOT || process.argv.slice(2).indexOf('--take-snapshot');
-const snapshotName = isTakeSnapshot > -1 ? process.argv.slice(2)[isTakeSnapshot + 1] : null;
+const snapshotName = process.env.SNAPSHOT_NAME || (isTakeSnapshot > -1 ? process.argv.slice(2)[isTakeSnapshot + 1] : null);
 
 const type = (snapshotName && snapshotName.match(/^[a-z\d_]/) ? snapshotName : null)
   || (isTakeSnapshot !== -1 ? 'base' : 'actual');


### PR DESCRIPTION
Hi,
since we use our own test runner and call testcafe via API invocation we can not pass the snapshot name through cli. Is it possible through your API somehow? If not please consider my change, this would add another environment variable to pass the screenshot name to your library. Or perhaps you have an even better idea to achieve the same 😃 

Thanks!