### PR TITLE
blockOut area and dpi per snapshot and ensure blocked elements are not out of bounds

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -153,21 +153,27 @@ function build() {
     const actualImage = path.relative(imagesPath, images[groupedName][right]);
     const baseImage = path.relative(imagesPath, images[groupedName][left]);
     const baseDir = path.dirname(images[groupedName][left]);
-    const metaFile = path.join(baseDir, 'blockOut.json');
+    const legacyBlockFile = path.join(baseDir, 'blockOut.json');
+    const blockFileA = path.join(baseDir, `blockOut-${left}.json`);
+    const blockFileB = path.join(baseDir, `blockOut-${right}.json`);
     const outFile = path.join(baseDir, 'out.png');
 
     tasks.push(new Promise(resolve => {
-      const blocks = fs.existsSync(metaFile) ? require(metaFile) : [];
-      const name = path.basename(images[groupedName][left], '.png');
-      const dpi = name.split('@')[1] || 1;
+      const legacyBlockOut = fs.existsSync(legacyBlockFile) ? require(legacyBlockFile) : [];
+      const blockOutA = fs.existsSync(blockFileA) ? require(blockFileA) : null;
+      const blockOutB = fs.existsSync(blockFileB) ? require(blockFileB) : null;
+      const nameA = path.basename(images[groupedName][left], '.png');
+      const nameB = path.basename(images[groupedName][right], '.png');
 
       const diff = new ImageDiff({
         imageOutputPath: outFile,
         imageAPath: images[groupedName][left],
         imageBPath: images[groupedName][right],
-        resolution: dpi,
+        resolutionA: nameA.split('@')[1] || 1,
+        resolutionB: nameB.split('@')[1] || 1,
         threshold: ratio,
-        blockOut: blocks,
+        blockOutA: blockOutA || legacyBlockOut,
+        blockOutB: blockOutB || legacyBlockOut,
       });
 
       return diff.run(() => {
@@ -201,7 +207,9 @@ function build() {
           width: diff.width,
           label: fixedName,
           diff: fixed,
-          dpi,
+          dpi: diff.options.resolutionA,
+          dpiActual: diff.options.resolutionB,
+          dpiBase: diff.options.resolutionA,
           ok,
         });
       });

--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -63,7 +63,6 @@ class ImageDiff {
     this.options = { ...opts };
     this.width = 0;
     this.height = 0;
-    this.resolution = 0;
     this.differences = 0;
   }
 
@@ -76,16 +75,24 @@ class ImageDiff {
       height: Math.max(aImage.height, bImage.height),
     });
 
-    if (this.options.blockOut) {
-      const dpi = this.options.resolution || 1;
-
-      [].concat(this.options.blockOut).forEach(area => {
+    if (this.options.blockOutA) {
+      [].concat(this.options.blockOutA).forEach(area => {
         const {
           x, y, w, h,
-        } = getBlockOutArea(dstImage, area, dpi);
-
-        fillPngRect(aImage, x, y, w, h);
-        fillPngRect(bImage, x, y, w, h);
+        } = getBlockOutArea(aImage, area, this.options.resolutionA || 1);
+        if (w && h && x < aImage.width && y < aImage.height) {
+          fillPngRect(aImage, x, y, Math.min(w, aImage.width - x), Math.min(h, aImage.height - y));
+        }
+      });
+    }
+    if (this.options.blockOutB) {
+      [].concat(this.options.blockOutB).forEach(area => {
+        const {
+          x, y, w, h,
+        } = getBlockOutArea(bImage, area, this.options.resolutionB || 1);
+        if (w && h && x < bImage.width && y < bImage.height) {
+          fillPngRect(bImage, x, y, Math.min(w, bImage.width - x), Math.min(h, bImage.height - y));
+        }
       });
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -150,7 +150,8 @@ function _takeSnapshot(t, opts, extra) {
           }
 
           const baseDir = path.join(screenshotsDir, path.dirname(imagePath));
-          const metaFile = path.join(baseDir, 'blockOut.json');
+          const blockOutName = `blockOut-${type}.json`;
+          const metaFile = path.join(baseDir, blockOutName);
 
           fs.writeFileSync(metaFile, JSON.stringify(results.filter(Boolean)));
         });


### PR DESCRIPTION
Save and applies the blockOut.json areas and dpi for each snapshots separately.

Ensure blocked elements that are out of bounds are not throwing `bitblt reading outside image` fix #49

tested and it works fine