### PR TITLE
fix: add boundTestRun option to ClientFunction

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,7 @@ function _takeSnapshot(t, opts, extra) {
     debug(`Selector('${x[key].fn}') was not found on the DOM`, options);
   }
 
-  const getWindowDPI = ClientFunction(() => window.devicePixelRatio);
+  const getWindowDPI = ClientFunction(() => window.devicePixelRatio).with({ boundTestRun: t });
 
   let dpi;
   function fixedName() {


### PR DESCRIPTION
# Description

Hi,
we use this package with complex usecase, and we had error below.
Since this, I'd like to add boundTestRun option to ClientFunction.
I'm apologize to I couldn't reproduce on repo's unittest.

```console
> npx testcafe chrome:headless tests/tests/index.js --take-snapshot actual --skip-js-errors --page-load-timeout 5000 -f custom
 Running tests in:
 - Chrome 108.0.5359.72 / Windows 10

 custom
Start: custom
   1: foo
   2: bar
 × custom (screenshots: C:\Users\user\Documents\sample\tests\screenshots)

   1) ClientFunction cannot implicitly resolve the test run in context of which it should be executed. If you need to call ClientFunction from the
      Node.js API callback, pass the test controller manually via ClientFunction's `.with({ boundTestRun: t })` method first. Note that you cannot
      execute ClientFunction outside the test code.

      Browser: Chrome 108.0.5359.72 / Windows 10
      Screenshot:
      C:\Users\user\Documents\sample\tests\screenshots\2022-12-01_15-16-31\test-1\Chrome_108.0.5359.72_Windows_10\errors\1.png

         82 |    return dpi > 1 ? imagePath.replace('.png', `@${dpi}.png`) : imagePath;
         83 |  }
         84 |
         85 |  return Promise.resolve()
         86 |    .then(() => t.wait(options.timeout === false ? 0 : (options.timeout || 500)))
       > 87 |    .then(() => getWindowDPI().then(value => { dpi = value || 1; }))
         88 |    .then(() => {
         89 |      if (!selectors) {
         90 |        return Promise.resolve()
         91 |          // testcafe's api for takeScreenshot has changed:
      https://devexpress.github.io/testcafe/documentation/test-api/actions/take-screenshot.html
         92 |          .then(() => !found && t.takeScreenshot({ path: fixedName(), fullPage: options.fullPage }))

         at <anonymous> (C:\Users\user\Documents\sample\node_modules\testcafe-blink-diff\lib\index.js:87:17)



 1/1 failed (11s)
```

## Type of change

- [x] Improvement (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unittest
    - ```
      > npx testcafe chrome:headless --screenshots-full-page --take-snapshot actual -s e2e/screens e2e/cases
      ```

- [x] ok on my repository with add change node_modules package

**Test Configuration**:

* OS: Windows10 21H2 19044.2251
* nodejs: v16.18.1
* npm: 9.1.2
* Packages:
    * testcafe@2.0.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes