### PR TITLE
Generate diff image more reliably

### DIFF
--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -102,7 +102,7 @@ class ImageDiff {
     const options = { threshold: 0.1, diffMask: true };
     const result = pixelmatch(aCanvas.data, bCanvas.data, dstImage.data, dstImage.width, dstImage.height, options);
 
-    dstImage.pack().pipe(fs.createWriteStream(this.getImageOutput()));
+    fs.writeFileSync(this.getImageOutput(), PNG.sync.write(dstImage));
 
     callback(Object.assign(this, {
       width: dstImage.width,


### PR DESCRIPTION
For some unknown reason, the `out.png` file was not reliably created. Sometimes the file was there, sometimes not. Sometimes it was an unopenable file, sometimes not. I took a look at the [pixelmatch](https://github.com/mapbox/pixelmatch?tab=readme-ov-file#nodejs) documentation and saw their preferred way to generate the diff image. I tried it in `testcafe-blink-diff` and it worked without reliability problems.