### PR TITLE
add some commands on npm and fix windows npm install prebuild problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ deps: package*.json
 	@(((ls node_modules | grep .) > /dev/null 2>&1) || npm i) || true
 
 clean:
-	@rm -rf dist/*
+	@npm run clean
 
 release: deps
 ifneq ($(CI),)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dist"
   ],
   "scripts": {
-    "dist": "mkdir -p dist && npm run build",
+    "clean": "rimraf dist/",
+    "dist": "npm run clean && mkdirp dist/ && npm run build",
     "build": "bili --format umd-min --module-name reporter --minimal --file-name reporter.umd.js",
     "serve": "sirv e2e/public --port 3000",
     "prepublish": "npm run dist",
@@ -38,6 +39,8 @@
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.22.1",
     "is-svg": ">=4.2.2",
+    "mkdirp": "^3.0.1",
+    "rimraf": "^6.0.1",
     "sirv-cli": "^1.0.14",
     "somedom": "^0.4.20",
     "testcafe": "^2.0.1"


### PR DESCRIPTION
# Description

HI,
I use windows native and I could npm install with prebuild not work on windows problems.
I'd like to fix it with use mkdirp/rimraf that corss platform tools. How about use that.

* [node.js - cross platform "rm" command - Stack Overflow](https://stackoverflow.com/questions/48120889/cross-platform-rm-command)
* [node.js - Can't use mkdir in NPM script from Windows - Stack Overflow](https://stackoverflow.com/questions/39727920/cant-use-mkdir-in-npm-script-from-windows)

## Type of change

* Improvement (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] unittest

```console
> & npm i
> & npx sirv e2e/public --port 3000
> & si -Path Env:\BASE_URL -Value "http://localhost:3000"
> & npx testcafe edge:headless e2e/cases -s path=e2e/screens --take-snapshot
```

- [x] ok on my repository with add change node_modules package

## Test Configuration:

It could run windows and WSL2 (CentOS Stream release 9, node 22.0.0, npm 10.5.1)

- OS: Windows11 23H2 22631.4037
- nodejs: v20.17.0
- npm: 10.8.3
- Packages:
   - testcafe@2.6.2

## Checklist:
- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my code
- [x]  My changes generate no new warnings
- [x]  New and existing unit tests pass locally with my changes

