### PR TITLE
fix: tests to care windows/others display resolution diff

### DIFF
--- a/e2e/cases/setting.test.js
+++ b/e2e/cases/setting.test.js
@@ -39,11 +39,11 @@ test('should care environment variables', async t => {
 
   const pngWithEnv = sizeOf(join(basePath, 'after__set__env', fixedFile('base.png')));
   await t.expect(pngWithEnv.width).eql(fixedSize(1290));
-  await t.expect(pngWithEnv.height).eql(fixedSize(1356));
+  await t.expect(pngWithEnv.height).gte(fixedSize(1356));
 
   const pngWithOutEnv = sizeOf(join(basePath, 'after__del__env', fixedFile('base.png')));
-  await t.expect(pngWithOutEnv.width).eql(fixedSize(640));
-  await t.expect(pngWithOutEnv.height).eql(fixedSize(480));
+  await t.expect(pngWithOutEnv.width).gte(fixedSize(625));
+  await t.expect(pngWithOutEnv.height).gte(fixedSize(465));
 });
 
 fixture('Testing set TAKE_SNAPSHOT')

--- a/e2e/cases/setting.test.js
+++ b/e2e/cases/setting.test.js
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-const { join } = require('node:path');
+import { join } from 'node:path';
 
 import sizeOf from 'image-size';
 import { rimrafSync } from 'rimraf';


### PR DESCRIPTION
# Description

Hi,
I couldn't pass #72, so I change some tests, please check it

Substantial commit ids are below:

- 964b02a0aae2cad868ad81c65b961fdc2df736f8
- 86fe883a1e712994cc8c2e1247194b6c0bb49f30

## Type of change:

Improvement (non-breaking change which fixes an issue)

## How Has This Been Tested?:

- [x] unittest

```console
> & npm i
> & npx sirv e2e/public --port 3000
> & si -Path Env:\BASE_URL -Value "http://localhost:3000"
> & si -Path Env:\WINDOW_DPI -Value 1
> & npx testcafe edge:headless e2e/cases -s path=e2e/screens
```

- [x] ok on my repository with add change node_modules package

## Test Configuration:

- OS: Windows11 23H2 22631.4112
- nodejs: v20.17.0
- npm: 10.8.3
- Packages:
   - testcafe@2.6.2

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
