### PR TITLE
fix: check image size betweenness, add argument tests

### DIFF
--- a/e2e/cases/cli.tests.js
+++ b/e2e/cases/cli.tests.js
@@ -1,29 +1,12 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { spawn } from 'node:child_process';
-import process from 'node:process';
-
 import sizeOf from 'image-size';
 import { rimrafSync } from 'rimraf';
 
-import { getBaseUrl, fixedSize, fixedFile } from '../lib';
-
-async function callCmd(targetTest, additionalArgs) {
-  const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-  const browser = process.env.BROWSER != null ? process.env.BROWSER : 'chrome:headless';
-  const baseArgs = ['testcafe', browser, targetTest, '-s', 'path=e2e/screens', '-q'];
-  const args = baseArgs.concat(additionalArgs);
-
-  const result = await new Promise(function fn(resolve) {
-    const cmd = spawn(npx, args, { shell: true, stdio: 'inherit' });
-
-    cmd.on('close', function onClose() {
-      resolve();
-    });
-  });
-  return result;
-}
+import {
+  getBaseUrl, fixedSize, fixedFile, callTC,
+} from '../lib';
 
 fixture('Testing cli --take-snapshot').page(getBaseUrl());
 
@@ -31,7 +14,7 @@ test('should care arg without name', async t => {
   const basePath = join('e2e', 'screens', 'Testing_cli', 'assert__it');
   rimrafSync(basePath);
 
-  await callCmd('e2e/file/cases/takesnapshot.test.js', ['--take-snapshot', 'base', '-t', 'takesnapshot']);
+  await callTC('e2e/file/cases/takesnapshot.test.js', ['--take-snapshot', 'base', '-t', 'takesnapshot']);
 
   await t.expect(existsSync(join(basePath, fixedFile('base.png')))).ok();
 });
@@ -41,9 +24,9 @@ test('should care arg with name', async t => {
   rimrafSync(basePath);
 
   const fpath = 'e2e/file/cases/takesnapshot.test.js';
-  await callCmd(fpath, ['--take-snapshot', 'base', '-t', 'takesnapshot']);
-  await callCmd(fpath, ['--take-snapshot', 'actual', '-t', 'takesnapshot']);
-  await callCmd(fpath, ['--take-snapshot', 'foo', '-t', 'takesnapshot']);
+  await callTC(fpath, ['--take-snapshot', 'base', '-t', 'takesnapshot']);
+  await callTC(fpath, ['--take-snapshot', 'actual', '-t', 'takesnapshot']);
+  await callTC(fpath, ['--take-snapshot', 'foo', '-t', 'takesnapshot']);
 
   await t.expect(existsSync(join(basePath, fixedFile('base.png')))).ok();
   await t.expect(existsSync(join(basePath, fixedFile('actual.png')))).ok();
@@ -58,8 +41,8 @@ test('should care arg', async t => {
   rimrafSync(basePath);
 
   const fpath = 'e2e/file/cases/takesnapshot.test.js';
-  await callCmd(fpath, ['--take-snapshot', '--full-page', '-t', 'fullpage']);
-  await callCmd(fpath, ['--take-snapshot', '-t', 'nofullpage']);
+  await callTC(fpath, ['--take-snapshot', '--full-page', '-t', 'fullpage']);
+  await callTC(fpath, ['--take-snapshot', '-t', 'nofullpage']);
 
   const pngFull = sizeOf(join(basePath, 'assert__it__with__fullpage', fixedFile('base.png')));
   await t.expect(pngFull.width).eql(fixedSize(1290));

--- a/e2e/cases/cli.tests.js
+++ b/e2e/cases/cli.tests.js
@@ -1,0 +1,73 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { spawn } from 'node:child_process';
+import process from 'node:process';
+
+import sizeOf from 'image-size';
+import { rimrafSync } from 'rimraf';
+
+import { getBaseUrl, fixedSize, fixedFile } from '../lib';
+
+async function callCmd(targetTest, additionalArgs) {
+  const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+  const browser = process.env.BROWSER != null ? process.env.BROWSER : 'chrome:headless';
+  const baseArgs = ['testcafe', browser, targetTest, '-s', 'path=e2e/screens', '-q'];
+  const args = baseArgs.concat(additionalArgs);
+
+  const result = await new Promise(function fn(resolve) {
+    const cmd = spawn(npx, args, { shell: true, stdio: 'inherit' });
+
+    cmd.on('close', function onClose() {
+      resolve();
+    });
+  });
+  return result;
+}
+
+fixture('Testing cli --take-snapshot').page(getBaseUrl());
+
+test('should care arg without name', async t => {
+  const basePath = join('e2e', 'screens', 'Testing_cli', 'assert__it');
+  rimrafSync(basePath);
+
+  await callCmd('e2e/file/cases/takesnapshot.test.js', ['--take-snapshot', 'base', '-t', 'takesnapshot']);
+
+  await t.expect(existsSync(join(basePath, fixedFile('base.png')))).ok();
+});
+
+test('should care arg with name', async t => {
+  const basePath = join('e2e', 'screens', 'Testing_cli', 'assert__it');
+  rimrafSync(basePath);
+
+  const fpath = 'e2e/file/cases/takesnapshot.test.js';
+  await callCmd(fpath, ['--take-snapshot', 'base', '-t', 'takesnapshot']);
+  await callCmd(fpath, ['--take-snapshot', 'actual', '-t', 'takesnapshot']);
+  await callCmd(fpath, ['--take-snapshot', 'foo', '-t', 'takesnapshot']);
+
+  await t.expect(existsSync(join(basePath, fixedFile('base.png')))).ok();
+  await t.expect(existsSync(join(basePath, fixedFile('actual.png')))).ok();
+  await t.expect(existsSync(join(basePath, fixedFile('foo.png')))).ok();
+  await t.expect(existsSync(join(basePath, fixedFile('bar.png')))).notOk();
+});
+
+fixture('Testing cli --full-page').page(getBaseUrl());
+
+test('should care arg', async t => {
+  const basePath = join('e2e', 'screens', 'Testing_cli');
+  rimrafSync(basePath);
+
+  const fpath = 'e2e/file/cases/takesnapshot.test.js';
+  await callCmd(fpath, ['--take-snapshot', '--full-page', '-t', 'fullpage']);
+  await callCmd(fpath, ['--take-snapshot', '-t', 'nofullpage']);
+
+  const pngFull = sizeOf(join(basePath, 'assert__it__with__fullpage', fixedFile('base.png')));
+  await t.expect(pngFull.width).eql(fixedSize(1290));
+  await t.expect(pngFull.height).gte(fixedSize(1356));
+
+  const pngNoFull = sizeOf(join(basePath, 'assert__it__without__fullpage', fixedFile('base.png')));
+  await t.expect(pngNoFull.width).gte(fixedSize(623));
+  await t.expect(pngNoFull.width).lte(fixedSize(640));
+  await t.expect(pngNoFull.height).gte(fixedSize(463));
+  await t.expect(pngNoFull.height).lte(fixedSize(480));
+});

--- a/e2e/cases/setting.test.js
+++ b/e2e/cases/setting.test.js
@@ -4,25 +4,11 @@ import { join } from 'node:path';
 import sizeOf from 'image-size';
 import { rimrafSync } from 'rimraf';
 
+import { fixedSize, fixedFile } from '../lib';
 import { takeSnapshot } from '../../lib';
 
 fixture('Testing set FULL_PAGE')
 .page(`${process.env.BASE_URL}/`);
-
-// this enforces a particular DPI to allow
-// tests to behave in a deterministic way!!
-process.env.WINDOW_DPI = process.env.WINDOW_DPI || "2";
-
-function fixedSize(value) {
-  return value * process.env.WINDOW_DPI;
-}
-
-function fixedFile(name) {
-  if (process.env.WINDOW_DPI > 1) {
-    return name.replace('.', `@${process.env.WINDOW_DPI}.`);
-  }
-  return name;
-}
 
 test('should care environment variables', async t => {
   process.env.TAKE_SNAPSHOT = "1";
@@ -42,8 +28,10 @@ test('should care environment variables', async t => {
   await t.expect(pngWithEnv.height).gte(fixedSize(1356));
 
   const pngWithOutEnv = sizeOf(join(basePath, 'after__del__env', fixedFile('base.png')));
-  await t.expect(pngWithOutEnv.width).gte(fixedSize(625));
-  await t.expect(pngWithOutEnv.height).gte(fixedSize(465));
+  await t.expect(pngWithOutEnv.width).gte(fixedSize(623));
+  await t.expect(pngWithOutEnv.width).lte(fixedSize(640));
+  await t.expect(pngWithOutEnv.height).gte(fixedSize(463));
+  await t.expect(pngWithOutEnv.height).lte(fixedSize(480));
 });
 
 fixture('Testing set TAKE_SNAPSHOT')

--- a/e2e/cases/setting.test.js
+++ b/e2e/cases/setting.test.js
@@ -39,11 +39,11 @@ test('should care environment variables', async t => {
 
   const pngWithEnv = sizeOf(join(basePath, 'after__set__env', fixedFile('base.png')));
   await t.expect(pngWithEnv.width).eql(fixedSize(1290));
-  await t.expect(pngWithEnv.height).eql(fixedSize(1356));
+  await t.expect(pngWithEnv.height).gte(fixedSize(1356));
 
   const pngWithOutEnv = sizeOf(join(basePath, 'after__del__env', fixedFile('base.png')));
-  await t.expect(pngWithOutEnv.width).eql(fixedSize(640));
-  await t.expect(pngWithOutEnv.height).eql(fixedSize(480));
+  await t.expect(pngWithOutEnv.width).gte(fixedSize(625));
+  await t.expect(pngWithOutEnv.height).gte(fixedSize(465));
 });
 
 fixture('Testing set TAKE_SNAPSHOT')

--- a/e2e/cases/setting.test.js
+++ b/e2e/cases/setting.test.js
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-const { join } = require('node:path');
+import { join } from 'node:path';
 
 import sizeOf from 'image-size';
 import { rimrafSync } from 'rimraf';

--- a/e2e/file/cases/takesnapshot.test.js
+++ b/e2e/file/cases/takesnapshot.test.js
@@ -1,0 +1,18 @@
+import { getBaseUrl } from '../../lib';
+import { takeSnapshot } from '../../../lib';
+
+fixture('Testing cli').page(getBaseUrl());
+
+test('takesnapshot', async t => {
+  await takeSnapshot(t, 'assert_it');
+});
+
+test('fullpage', async t => {
+  await t.resizeWindow(640, 480);
+  await takeSnapshot(t, 'assert_it_with_fullpage');
+});
+
+test('nofullpage', async t => {
+  await t.resizeWindow(640, 480);
+  await takeSnapshot(t, 'assert_it_without_fullpage');
+});

--- a/e2e/lib.js
+++ b/e2e/lib.js
@@ -1,0 +1,20 @@
+// this enforces a particular DPI to allow
+// tests to behave in a deterministic way!!
+process.env.WINDOW_DPI = process.env.WINDOW_DPI || '2';
+
+function getBaseUrl() {
+  return `${process.env.BASE_URL}/`;
+}
+
+function fixedSize(value) {
+  return value * process.env.WINDOW_DPI;
+}
+
+function fixedFile(name) {
+  if (process.env.WINDOW_DPI > 1) {
+    return name.replace('.', `@${process.env.WINDOW_DPI}.`);
+  }
+  return name;
+}
+
+export { getBaseUrl, fixedSize, fixedFile };

--- a/e2e/lib.js
+++ b/e2e/lib.js
@@ -1,3 +1,6 @@
+import { spawn } from 'node:child_process';
+import process from 'node:process';
+
 // this enforces a particular DPI to allow
 // tests to behave in a deterministic way!!
 process.env.WINDOW_DPI = process.env.WINDOW_DPI || '2';
@@ -17,4 +20,24 @@ function fixedFile(name) {
   return name;
 }
 
-export { getBaseUrl, fixedSize, fixedFile };
+function callNpx(args) {
+  const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+
+  return new Promise(function fn(resolve) {
+    const cmd = spawn(npx, args, { shell: true, stdio: 'inherit' });
+
+    cmd.on('close', function onClose() {
+      resolve();
+    });
+  });
+}
+
+function callTC(targetTest, additionalArgs) {
+  const browser = process.env.BROWSER != null ? process.env.BROWSER : 'chrome:headless';
+  const baseArgs = ['testcafe', browser, targetTest, '-s', 'path=e2e/screens', '-q'];
+  return callNpx(baseArgs.concat(additionalArgs));
+}
+
+export {
+  getBaseUrl, fixedSize, fixedFile, callTC,
+};


### PR DESCRIPTION
# Description

Hi,
I make [link][link]'s idea to be a real, I fix some tests, and add cli tests (the execution needs some time)

This is chain pr from #73 

Substantial commit ids are below:

- 19aa4f04bfc1
- a4ab3a1303a3

[link]: https://github.com/tacoss/testcafe-blink-diff/pull/73#issuecomment-2322777475

## Type of change:

Improvement (non-breaking change which fixes an issue)

## How Has This Been Tested?:

- [x] unittest

```console
> & npm i
> & npx sirv e2e/public --port 3000
> & si -Path Env:\BASE_URL -Value "http://localhost:3000"
> & si -Path Env:\WINDOW_DPI -Value 1
> & npx testcafe edge:headless e2e/cases -s path=e2e/screens
```

- [x] ok on my repository with add change node_modules package

## Test Configuration:

- OS: Windows11 23H2 22631.4112
- nodejs: v20.17.0
- npm: 10.8.3
- Packages:
   - testcafe@2.6.2

Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
